### PR TITLE
Remove YouTube Music from page title

### DIFF
--- a/app/script.js
+++ b/app/script.js
@@ -222,7 +222,7 @@ function getSongTitle(titleOfPage) {
     var pageTitle = titleOfPage.toLowerCase();
 
     // do the bracketed ones first otherwise it wont match properly and leave brackets "()" behind!!
-    var stringsToRemove = [" - youtube", "youtube", " (official music video)", "official music video",
+    var stringsToRemove = [" - youtube music", " - youtube", "youtube", " (official music video)", "official music video",
     "(official video)", "official video", "(official audio)", " (audio)", " | a colors show", " ft.", 
     "-", "(lyric video)", "lyric video", "(lyrics video)", "lyrics video", "(lyrics)", 
     "lyrics", "(lyric)", "lyric", "†"];


### PR DESCRIPTION
for better search results there.

The extension works well on music.youtube.com too otherwise, it just wasn't clearing the " music" part from the titles so search results weren't good.